### PR TITLE
Fix unnecessarily large window height

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -2,21 +2,24 @@ import React from "react";
 
 function Footer() {
   return (
-    <div className="footer">
-      <div className="footer-div">
-        <p className="footer-text">
-          &copy;{" "}
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://github.com/oftheheadland"
-            className="footer-link"
-          >
-            Oftheheadland
+    <>
+      <div className="footer-margin" />
+      <div className="footer">
+        <div className="footer-div">
+          <p className="footer-text">
+            &copy;{" "}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://github.com/oftheheadland"
+              className="footer-link"
+            >
+              Oftheheadland
           </a>
-        </p>
-      </div>
-    </div>
+          </p>
+        </div>
+      </div >
+    </>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -172,7 +172,6 @@ code {
 .outer-container {
   max-width: 75%;
   margin: auto;
-  min-height: 90vh;
 }
 @media only screen and (max-width: 1300px) {
   .outer-container {
@@ -210,7 +209,7 @@ code {
 }
 
 .footer {
-  /* position: fixed; */
+  position: fixed;
   left: 0;
   bottom: 0;
   width: 100%;
@@ -229,6 +228,16 @@ code {
 
 .footer p a {
   color: white;
+}
+
+.footer-div {
+  padding: 5px;
+  margin: auto;
+}
+
+/* same height as footer-div, prevents floating footer from overlapping content */
+.footer-margin {
+  height: 40px;
 }
 
 header {
@@ -705,7 +714,6 @@ hr {
 .about-container {
   max-width: 1150px;
   margin: auto;
-  min-height: 100vh;
   padding: 5px;
 }
 @media only screen and (max-width: 1300px) {
@@ -737,11 +745,6 @@ hr {
 }
 
 .ReactModal__Content {
-  margin: auto;
-}
-
-.footer-div {
-  padding: 5px;
   margin: auto;
 }
 


### PR DESCRIPTION
Annoyed me that the page was always bigger than the screen, even if there was nothing to fill the screen with, making the footer always outside the initial screen, and the scrollbar always visible.

By the looks of the commented out `position: fixed` in the footer, it seems you had already tried this, but had some trouble for one reason or another. I added an extra empty div (footer-margin) that isn't `position: fixed`, so it will stay glued to the end of the content. This prevents the situation where some of the page content stays hidden behind the footer and can't be accessed through scrolling.

When reading the diff here in GitHub, I suggest using the "hide whitespace changes" in the Diff Options, makes it easier to see the changes in the Footer file.

I know this is the project you used to learn React, and the end result looks quite good. The file structure makes things hard though. A single CSS file for everything makes it a bit hard to deal with :)